### PR TITLE
Add tween for hero animation

### DIFF
--- a/lib/pages/Home.dart
+++ b/lib/pages/Home.dart
@@ -57,6 +57,9 @@ class _HomeState extends State<Home> {
     );
   }
 
+  Tween<Rect> heroRectTween(Rect begin, Rect end) =>
+      RectTween(begin: begin, end: end);
+
   Widget buildGoalsList(List<Goal> goals) {
     double _width = MediaQuery.of(context).size.width * 0.75;
 
@@ -78,6 +81,7 @@ class _HomeState extends State<Home> {
                   Column(
                     children: <Widget>[
                       Hero(
+                        createRectTween: this.heroRectTween,
                         tag: "dartIcon${goal.id}",
                         child: Container(
                           width: 40.0,


### PR DESCRIPTION
By default, ```Hero``` animation uses  ```MaterialRectArcTween``` which causes this kind of slope animation for farther heros.
Using ```RectTween```, every hero now has similar animation regardless of the position, which is kinda linear/snappy animation between the two positions.
If this what are looking for, this PR should close #3 .😄